### PR TITLE
added two new methods clear_key_before and clear_key_after

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_script:
 script: make check
 matrix:
   allow_failures:
-    - "pypy"
+    - "python": "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ before_script:
   - mysql -e 'create database gauged;'
   - psql -c 'create database gauged;' -U postgres
 script: make check
-matrix:
-  allow_failures:
-    - "python": "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ before_script:
   - mysql -e 'create database gauged;'
   - psql -c 'create database gauged;' -U postgres
 script: make check
+matrix:
+  allow_failures:
+    - "pypy"

--- a/gauged/context.py
+++ b/gauged/context.py
@@ -225,7 +225,7 @@ class Context(object):
                 if cache_until_timestamp >= end and start not in cached:
                     to_cache.append(( start, value ))
             if len(to_cache):
-                driver.add_cache(namespace, cache_key, interval, to_cache)
+                driver.add_cache(namespace, key, cache_key, interval, to_cache)
         return TimeSeries(( (start, value) for start, _, value in values \
             if value is not None ))
 
@@ -264,7 +264,7 @@ class Context(object):
                 if cache_until_timestamp >= end and start not in cached:
                     to_cache.append(( start, result ))
             if len(to_cache):
-                driver.add_cache(namespace, cache_key, interval, to_cache)
+                driver.add_cache(namespace, key, cache_key, interval, to_cache)
         return TimeSeries(( (start, value) for start, _, value in values ))
 
     def block_iterator(self, key, start, end, yield_if_empty=False):

--- a/gauged/drivers/interface.py
+++ b/gauged/drivers/interface.py
@@ -66,10 +66,10 @@ class DriverInterface(object):
     def clear_from(self, offset, timestamp):
         raise NotImplementedError
 
-    def clear_key_after(self, key, namespace, offset, timestamp):
+    def clear_key_after(self, key, namespace, offset=None, timestamp=None):
         raise NotImplementedError
 
-    def clear_key_before(self, key, namespace, offset, timestamp):
+    def clear_key_before(self, key, namespace, offset=None, timestamp=None):
         raise NotImplementedError
 
     def get_cache(self, namespace, query_hash, length, start, end):

--- a/gauged/drivers/interface.py
+++ b/gauged/drivers/interface.py
@@ -4,6 +4,7 @@ https://github.com/chriso/gauged (MIT Licensed)
 Copyright 2014 (c) Chris O'Hara <cohara87@gmail.com>
 '''
 
+
 class DriverInterface(object):
 
     MAX_KEY = 1024
@@ -19,57 +20,6 @@ class DriverInterface(object):
 
     def prepare_migrations(self):
         raise NotImplementedError
-
-    def migrate(self, goto_version, debug=False):
-        migrations = self.prepare_migrations()
-        if not migrations:
-            return "migrations not implemented"
-        if goto_version is None:
-            return "version to migrate to not specified"
-        if goto_version not in migrations:
-            return "%s not found on allowed migrations" % goto_version
-        current_meta = self.all_metadata()
-        current_version = current_meta['initial_version']
-        if current_version > goto_version:
-            return "You have a newer schema than the current version"
-        migrate = False
-        for version, upgrade_script in migrations.iteritems():
-            if debug:
-                print '-'*20
-                print 'from/to version', "%s/%s" % (current_version, version)
-                print 'upgrade', upgrade_script
-            # skip until current version
-            if version <= current_version:
-                if debug:
-                    print 'skipping because already done'
-                continue
-            elif version > goto_version:
-                if debug:
-                    print 'skipping because not needed'
-                break
-            # if migration is found but empty, skip to next
-            if not upgrade_script:
-                if debug:
-                    print 'skipping because migration empty'
-                current_version = version
-                continue
-            # if migration is found, needs to be executed
-            success = False
-            try:
-                if debug:
-                    print 'executing %s' % upgrade_script
-                self.cursor.executescript(upgrade_script)
-                self.db.commit()
-            except:
-                self.db.rollback()
-                if debug:
-                    print 'failed to execute %s' % upgrade_script
-                return 'failure migrating to %s' % version
-            if debug:
-                print 'successfully migrated to %s' % version
-            self.set_metadata({'initial_version': version, 'current_version': version})
-            current_version = version
-
 
     def keys(self, namespace, prefix=None, limit=None, offset=None):
         raise NotImplementedError

--- a/gauged/drivers/interface.py
+++ b/gauged/drivers/interface.py
@@ -78,7 +78,7 @@ class DriverInterface(object):
     def add_cache(self, namespace, key, query_hash, length, cache):
         pass
 
-    def remove_cache(self, namespace, key):
+    def remove_cache(self, namespace, key=None):
         pass
 
     def add_namespace_statistics(self, namespace, offset,

--- a/gauged/drivers/interface.py
+++ b/gauged/drivers/interface.py
@@ -66,10 +66,10 @@ class DriverInterface(object):
     def clear_from(self, offset, timestamp):
         raise NotImplementedError
 
-    def clear_key_after(self, key, namespace, timestamp):
+    def clear_key_after(self, key, namespace, offset, timestamp):
         raise NotImplementedError
 
-    def clear_key_before(self, key, namespace, timestamp):
+    def clear_key_before(self, key, namespace, offset, timestamp):
         raise NotImplementedError
 
     def get_cache(self, namespace, query_hash, length, start, end):

--- a/gauged/drivers/interface.py
+++ b/gauged/drivers/interface.py
@@ -17,6 +17,60 @@ class DriverInterface(object):
     def drop_schema(self):
         raise NotImplementedError
 
+    def prepare_migrations(self):
+        raise NotImplementedError
+
+    def migrate(self, goto_version, debug=False):
+        migrations = self.prepare_migrations()
+        if not migrations:
+            return "migrations not implemented"
+        if goto_version is None:
+            return "version to migrate to not specified"
+        if goto_version not in migrations:
+            return "%s not found on allowed migrations" % goto_version
+        current_meta = self.all_metadata()
+        current_version = current_meta['initial_version']
+        if current_version > goto_version:
+            return "You have a newer schema than the current version"
+        migrate = False
+        for version, upgrade_script in migrations.iteritems():
+            if debug:
+                print '-'*20
+                print 'from/to version', "%s/%s" % (current_version, version)
+                print 'upgrade', upgrade_script
+            # skip until current version
+            if version <= current_version:
+                if debug:
+                    print 'skipping because already done'
+                continue
+            elif version > goto_version:
+                if debug:
+                    print 'skipping because not needed'
+                break
+            # if migration is found but empty, skip to next
+            if not upgrade_script:
+                if debug:
+                    print 'skipping because migration empty'
+                current_version = version
+                continue
+            # if migration is found, needs to be executed
+            success = False
+            try:
+                if debug:
+                    print 'executing %s' % upgrade_script
+                self.cursor.executescript(upgrade_script)
+                self.db.commit()
+            except:
+                self.db.rollback()
+                if debug:
+                    print 'failed to execute %s' % upgrade_script
+                return 'failure migrating to %s' % version
+            if debug:
+                print 'successfully migrated to %s' % version
+            self.set_metadata({'initial_version': version, 'current_version': version})
+            current_version = version
+
+
     def keys(self, namespace, prefix=None, limit=None, offset=None):
         raise NotImplementedError
 
@@ -62,13 +116,19 @@ class DriverInterface(object):
     def clear_from(self, offset, timestamp):
         raise NotImplementedError
 
+    def clear_key_after(self, key, namespace, timestamp):
+        raise NotImplementedError
+
+    def clear_key_before(self, key, namespace, timestamp):
+        raise NotImplementedError
+
     def get_cache(self, namespace, query_hash, length, start, end):
         pass
 
-    def add_cache(self, namespace, query_hash, length, cache):
+    def add_cache(self, namespace, key, query_hash, length, cache):
         pass
 
-    def remove_cache(self, namespace):
+    def remove_cache(self, namespace, key):
         pass
 
     def add_namespace_statistics(self, namespace, offset,

--- a/gauged/drivers/mysql.py
+++ b/gauged/drivers/mysql.py
@@ -198,26 +198,28 @@ class MySQLDriver(DriverInterface):
         execute('''UPDATE gauged_writer_history SET timestamp = %s
             WHERE timestamp > %s''', (timestamp, timestamp))
 
-    def clear_key_before(self, key, namespace, timestamp=None):
+    def clear_key_before(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
-            params = (translated_key, namespace, timestamp)
+            params = (translated_key, namespace, offset)
             execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s AND offset <= %s''', params)
+            params = (translated_key, namespace, timestamp)
             execute('''DELETE FROM gauged_cache WHERE `key` = %s AND namespace = %s AND start + length <= %s''', params)
         else:
             params = (translated_key, namespace)
             execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s''', params)
+            params = (translated_key, namespace, timestamp)
             execute('''DELETE FROM gauged_keys WHERE `key` = %s AND namespace = %s''', params)
             self.remove_cache(namespace, translated_key)
 
-    def clear_key_after(self, key, namespace, timestamp=None):
+    def clear_key_after(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
-            params = (translated_key, namespace, timestamp)
+            params = (translated_key, namespace, offset)
             execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s AND offset >= %s''', params)
             execute('''DELETE FROM gauged_cache WHERE `key` = %s AND namespace = %s AND start + length >= %s''', params)
         else:

--- a/gauged/drivers/mysql.py
+++ b/gauged/drivers/mysql.py
@@ -196,6 +196,34 @@ class MySQLDriver(DriverInterface):
         execute('''UPDATE gauged_writer_history SET timestamp = %s
             WHERE timestamp > %s''', (timestamp, timestamp))
 
+    def clear_key_before(self, key, namespace, timestamp=None):
+        namespace_key = (namespace, key)
+        translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
+        execute = self.cursor.execute
+        if timestamp is not None:
+            params = (translated_key, namespace, timestamp)
+            execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s AND offset <= %s''', params)
+            execute('''DELETE FROM gauged_cache WHERE `key` = %s AND namespace = %s AND start + length <= %s''', params)
+        else:
+            params = (translated_key, namespace)
+            execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s''', params)
+            execute('''DELETE FROM gauged_keys WHERE `key` = %s AND namespace = %s''', params)
+            self.remove_cache(namespace, translated_key)
+
+    def clear_key_after(self, key, namespace, timestamp=None):
+        namespace_key = (namespace, key)
+        translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
+        execute = self.cursor.execute
+        if timestamp is not None:
+            params = (translated_key, namespace, timestamp)
+            execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s AND offset >= %s''', params)
+            execute('''DELETE FROM gauged_cache WHERE `key` = %s AND namespace = %s AND start + length >= %s''', params)
+        else:
+            params = (translated_key, namespace)
+            execute('''DELETE FROM gauged_data WHERE `key` = %s AND namespace = %s''', params)
+            execute('''DELETE FROM gauged_keys WHERE `key` = %s AND namespace = %s''', params)
+            self.remove_cache(namespace, translated_key)
+
     def get_cache(self, namespace, query_hash, length, start, end):
         '''Get a cached value for the specified date range and query'''
         cursor = self.cursor
@@ -204,28 +232,32 @@ class MySQLDriver(DriverInterface):
             (namespace, query_hash, length, start, end))
         return cursor.fetchall()
 
-    def add_cache(self, namespace, query_hash, length, cache):
+    def add_cache(self, namespace, key, query_hash, length, cache):
         '''Add cached values for the specified date range and query'''
         start = 0
         bulk_insert = self.bulk_insert
         cache_len = len(cache)
-        row = '(%s,%s,%s,%s,%s)'
+        row = '(%s,%s,%s,%s,%s,%s)'
         query = '''INSERT IGNORE INTO gauged_cache
-            (namespace, hash, length, start, value) VALUES '''
+            (namespace, `key`, hash, length, start, value) VALUES '''
         execute = self.cursor.execute
         while start < cache_len:
             rows = cache[start:start+bulk_insert]
             params = []
             for timestamp, value in rows:
-                params.extend(( namespace, query_hash, length, timestamp, value ))
+                params.extend(( namespace, key, query_hash, length, timestamp, value ))
             insert = (row + ',') * (len(rows) - 1) + row
             execute(query + insert, params)
             start += bulk_insert
         self.db.commit()
 
-    def remove_cache(self, namespace):
-        '''Remove all cached values for the specified namespace'''
-        self.cursor.execute('DELETE FROM gauged_cache WHERE namespace = %s', (namespace,))
+    def remove_cache(self, namespace, key=None):
+        '''Remove all cached values for the specified namespace,
+        optionally specifying a key'''
+        if key is None:
+            self.cursor.execute('DELETE FROM gauged_cache WHERE namespace = %s', (namespace,))
+        else:
+            self.cursor.execute('DELETE FROM gauged_cache WHERE namespace = %s and `key` = %s', (namespace, key))
 
     def commit(self):
         '''Commit the current transaction'''
@@ -258,6 +290,7 @@ class MySQLDriver(DriverInterface):
         if 'gauged_cache' not in tables:
             execute('''CREATE TABLE gauged_cache (
                 namespace INT(11) UNSIGNED NOT NULL,
+                `key` BIGINT(15) UNSIGNED NOT NULL,
                 hash BINARY(20) NOT NULL,
                 length BIGINT(15) UNSIGNED NOT NULL,
                 start BIGINT(15) UNSIGNED NOT NULL,

--- a/gauged/drivers/postgresql.py
+++ b/gauged/drivers/postgresql.py
@@ -195,13 +195,14 @@ class PostgreSQLDriver(DriverInterface):
         execute('''UPDATE gauged_writer_history SET timestamp = %s
             WHERE timestamp > %s''', (timestamp, timestamp))
 
-    def clear_key_before(self, key, namespace, timestamp=None):
+    def clear_key_before(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
-            params = (translated_key, namespace, timestamp)
+            params = (translated_key, namespace, offset)
             execute('''DELETE FROM gauged_data WHERE key = %s AND namespace = %s AND "offset" <= %s''', params)
+            params = (translated_key, namespace, timestamp)
             execute('''DELETE FROM gauged_cache WHERE key = %s AND namespace = %s AND start + length <= %s''', params)
         else:
             params = (translated_key, namespace)
@@ -209,13 +210,14 @@ class PostgreSQLDriver(DriverInterface):
             execute('''DELETE FROM gauged_keys WHERE key = %s AND namespace = %s''', params)
             self.remove_cache(namespace, translated_key)
 
-    def clear_key_after(self, key, namespace, timestamp=None):
+    def clear_key_after(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
-            params = (translated_key, namespace, timestamp)
+            params = (translated_key, namespace, offset)
             execute('''DELETE FROM gauged_data WHERE key = %s AND namespace = %s AND "offset" >= %s''', params)
+            params = (translated_key, namespace, timestamp)
             execute('''DELETE FROM gauged_cache WHERE key = %s AND namespace = %s AND start + length >= %s''', params)
         else:
             params = (translated_key, namespace)

--- a/gauged/drivers/sqlite.py
+++ b/gauged/drivers/sqlite.py
@@ -189,13 +189,14 @@ class SQLiteDriver(DriverInterface):
         execute('''UPDATE gauged_writer_history SET timestamp = ?
             WHERE timestamp > ?''', (timestamp, timestamp))
 
-    def clear_key_before(self, key, namespace, timestamp=None):
+    def clear_key_before(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
+            params = (translated_key, namespace, offset)
+            execute('''DELETE FROM gauged_data WHERE `key` = ? AND namespace = ? AND offset <= ?''', (params))
             params = (translated_key, namespace, timestamp)
-            execute('''DELETE FROM gauged_data WHERE `key` = ? AND namespace = ? AND offset <= ?''', params)
             execute('''DELETE FROM gauged_cache WHERE `key` = ? AND namespace = ? AND start + length <= ?''', params)
         else:
             params = (translated_key, namespace)
@@ -203,13 +204,14 @@ class SQLiteDriver(DriverInterface):
             execute('''DELETE FROM gauged_keys WHERE `key` = ? AND namespace = ?''', params)
             self.remove_cache(namespace, translated_key)
 
-    def clear_key_after(self, key, namespace, timestamp=None):
+    def clear_key_after(self, key, namespace, offset=None, timestamp=None):
         namespace_key = (namespace, key)
         translated_key = self.lookup_ids((namespace_key,)).get(namespace_key)
         execute = self.cursor.execute
         if timestamp is not None:
-            params = (translated_key, namespace, timestamp)
+            params = (translated_key, namespace, offset)
             execute('''DELETE FROM gauged_data WHERE `key` = ? AND namespace = ? AND offset >= ?''', params)
+            params = (translated_key, namespace, timestamp)
             execute('''DELETE FROM gauged_cache WHERE `key` = ? AND namespace = ? AND start + length >= ?''', params)
         else:
             params = (translated_key, namespace)

--- a/gauged/drivers/sqlite.py
+++ b/gauged/drivers/sqlite.py
@@ -6,8 +6,8 @@ Copyright 2014 (c) Chris O'Hara <cohara87@gmail.com>
 from collections import OrderedDict
 from .interface import DriverInterface
 
-class SQLiteDriver(DriverInterface):
 
+class SQLiteDriver(DriverInterface):
 
     MAX_KEY = 255
 
@@ -338,8 +338,8 @@ class SQLiteDriver(DriverInterface):
     def prepare_migrations(self):
         migrations = OrderedDict()
         migrations['0.4.1'] = ''
-        migrations['0.4.2'] = '''
-        DROP TABLE IF EXISTS gauged_cache;
+        migrations['1.0.0'] = ['''
+        DROP TABLE IF EXISTS gauged_cache;''', '''
         CREATE TABLE IF NOT EXISTS gauged_cache (
                 namespace UNSIGNED INT NOT NULL,
                 `key` INTEGER NOT NULL,
@@ -348,5 +348,5 @@ class SQLiteDriver(DriverInterface):
                 start UNSIGNED BIGINT NOT NULL,
                 value FLOAT,
                 PRIMARY KEY (namespace, hash, length, start));
-        '''
+        ''']
         return migrations

--- a/gauged/drivers/sqlite.py
+++ b/gauged/drivers/sqlite.py
@@ -263,7 +263,7 @@ class SQLiteDriver(DriverInterface):
         execute('''INSERT OR IGNORE INTO gauged_statistics
             VALUES (?, ?, 0, 0)''', ( namespace, offset ))
         execute('''UPDATE gauged_statistics SET data_points = data_points + ?,
-            byte_count = byte_count + ? WHERE namespace = ? AND offset = ?''',
+           byte_count = byte_count + ? WHERE namespace = ? AND offset = ?''',
             ( data_points, byte_count, namespace, offset ))
 
     def get_namespace_statistics(self, namespace, start_offset, end_offset):
@@ -339,7 +339,7 @@ class SQLiteDriver(DriverInterface):
         migrations = OrderedDict()
         migrations['0.4.1'] = ''
         migrations['1.0.0'] = ['''
-        DROP TABLE IF EXISTS gauged_cache;''', '''
+        DROP TABLE IF EXISTS gauged_cache''', '''
         CREATE TABLE IF NOT EXISTS gauged_cache (
                 namespace UNSIGNED INT NOT NULL,
                 `key` INTEGER NOT NULL,
@@ -347,6 +347,6 @@ class SQLiteDriver(DriverInterface):
                 length UNSIGNED BIGINT NOT NULL,
                 start UNSIGNED BIGINT NOT NULL,
                 value FLOAT,
-                PRIMARY KEY (namespace, hash, length, start));
+                PRIMARY KEY (namespace, hash, length, start))
         ''']
         return migrations

--- a/gauged/errors/__init__.py
+++ b/gauged/errors/__init__.py
@@ -40,3 +40,6 @@ class GaugedBlockSizeMismatch(RuntimeWarning):
 
 class GaugedSchemaError(GaugedError):
     '''Occurs when an operation is attempted and no schema can be found'''
+
+class GaugedMigrationError(GaugedError):
+    '''Occurs when migration logic fails'''

--- a/gauged/gauged.py
+++ b/gauged/gauged.py
@@ -123,15 +123,6 @@ class Gauged(object):
             metadata = {}
         return metadata
 
-    def migrate(self, debug=False):
-        '''Migrate an old Gauged schema to the current version. This is
-        just a placeholder for now'''
-        rtn = self.driver.migrate(Gauged.VERSION, debug=debug)
-        if rtn:
-            msg = "Couldn't migrate schema\n"
-            msg += rtn
-            raise GaugedMigrationError(msg)
-
     def make_context(self, **kwargs):
         '''Create a new context for reading data'''
         self.check_schema()
@@ -147,7 +138,7 @@ class Gauged(object):
             raise GaugedSchemaError('Gauged schema not found, try a gauged.sync()')
         if metadata['current_version'] != Gauged.VERSION:
             msg = 'The schema is version %s while this Gauged is version %s. '
-            msg += 'Try upgrading Gauged and/or running gauged.migrate()'
+            msg += 'Try upgrading Gauged and/or running gauged_migrate.py'
             msg = msg % (metadata['current_version'], Gauged.VERSION)
             raise GaugedVersionMismatchError(msg)
         expected_block_size = '%s/%s' % (config.block_size, config.resolution)

--- a/gauged/gauged.py
+++ b/gauged/gauged.py
@@ -14,7 +14,7 @@ from .utilities import Time
 from .aggregates import Aggregate
 from .config import Config
 from .errors import (GaugedVersionMismatchError, GaugedBlockSizeMismatch,
-    GaugedSchemaError)
+    GaugedSchemaError, GaugedMigrationError)
 from .version import __version__
 
 class Gauged(object):
@@ -123,10 +123,14 @@ class Gauged(object):
             metadata = {}
         return metadata
 
-    def migrate(self):
+    def migrate(self, debug=False):
         '''Migrate an old Gauged schema to the current version. This is
         just a placeholder for now'''
-        self.driver.set_metadata({ 'current_version': Gauged.VERSION })
+        rtn = self.driver.migrate(Gauged.VERSION, debug=debug)
+        if rtn:
+            msg = "Couldn't migrate schema\n"
+            msg += rtn
+            raise GaugedMigrationError(msg)
 
     def make_context(self, **kwargs):
         '''Create a new context for reading data'''

--- a/gauged/structures/float_array.py
+++ b/gauged/structures/float_array.py
@@ -5,11 +5,13 @@ Copyright 2014 (c) Chris O'Hara <cohara87@gmail.com>
 '''
 
 from types import ListType, BufferType
-from ctypes import (create_string_buffer, c_void_p, pythonapi, py_object, byref,
+from ctypes import (create_string_buffer, c_void_p, py_object, byref,
     cast, addressof, c_char, c_size_t)
 from ..bridge import Gauged, FloatPtr
 from ..errors import GaugedUseAfterFreeError
 from ..utilities import IS_PYPY
+if not IS_PYPY:
+    from ctypes import pythonapi
 
 class FloatArray(object):
     '''An array of C floats'''

--- a/gauged/structures/sparse_map.py
+++ b/gauged/structures/sparse_map.py
@@ -5,11 +5,13 @@ Copyright 2014 (c) Chris O'Hara <cohara87@gmail.com>
 '''
 
 from types import DictType, BufferType
-from ctypes import (create_string_buffer, c_void_p, pythonapi, py_object, byref,
+from ctypes import (create_string_buffer, c_void_p, py_object, byref,
     cast, c_uint32, addressof, c_char, c_size_t, c_float)
 from ..bridge import Gauged, MapPtr, Uint32Ptr, FloatPtr
-from ..utilities import IS_PYPY
 from ..errors import GaugedUseAfterFreeError
+from ..utilities import IS_PYPY
+if not IS_PYPY:
+    from ctypes import pythonapi
 
 class SparseMap(object):
     '''A structure which adds another dimension to FloatArray. The

--- a/gauged/version.py
+++ b/gauged/version.py
@@ -4,6 +4,6 @@ https://github.com/chriso/gauged (MIT Licensed)
 Copyright 2014 (c) Chris O'Hara <cohara87@gmail.com>
 '''
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 __version_info__ = tuple([ int(v) for v in __version__.split('.') ])

--- a/gauged/writer.py
+++ b/gauged/writer.py
@@ -185,7 +185,7 @@ class Writer(object):
             offset, remainder = divmod(timestamp, block_size)
             if remainder:
                 raise ValueError('timestamp must be on a block boundary')
-            self.driver.clear_key_before(key, namespace, offset)
+            self.driver.clear_key_before(key, namespace, offset, timestamp)
         else:
             self.driver.clear_key_before(key, namespace)
 
@@ -199,7 +199,7 @@ class Writer(object):
             offset, remainder = divmod(timestamp, block_size)
             if remainder:
                 raise ValueError('timestamp must be on a block boundary')
-            self.driver.clear_key_after(key, namespace, offset)
+            self.driver.clear_key_after(key, namespace, offset, timestamp)
         else:
             self.driver.clear_key_after(key, namespace)
 

--- a/gauged/writer.py
+++ b/gauged/writer.py
@@ -185,7 +185,7 @@ class Writer(object):
             offset, remainder = divmod(timestamp, block_size)
             if remainder:
                 raise ValueError('timestamp must be on a block boundary')
-            if offset > 0:
+            if offset == 0:
                 raise ValueError('cannot delete before offset zero')
             offset -= 1
             self.driver.clear_key_before(key, namespace, offset, timestamp)

--- a/gauged/writer.py
+++ b/gauged/writer.py
@@ -186,7 +186,8 @@ class Writer(object):
             if remainder:
                 raise ValueError('timestamp must be on a block boundary')
             if offset > 0:
-                offset -= 1
+                raise ValueError('cannot delete before offset zero')
+            offset -= 1
             self.driver.clear_key_before(key, namespace, offset, timestamp)
         else:
             self.driver.clear_key_before(key, namespace)

--- a/gauged/writer.py
+++ b/gauged/writer.py
@@ -185,6 +185,8 @@ class Writer(object):
             offset, remainder = divmod(timestamp, block_size)
             if remainder:
                 raise ValueError('timestamp must be on a block boundary')
+            if offset > 0:
+                offset -= 1
             self.driver.clear_key_before(key, namespace, offset, timestamp)
         else:
             self.driver.clear_key_before(key, namespace)

--- a/gauged/writer.py
+++ b/gauged/writer.py
@@ -175,6 +175,34 @@ class Writer(object):
             raise ValueError('Timestamp must be on a block boundary')
         self.driver.clear_from(offset, timestamp)
 
+    def clear_key_before(self, key, namespace=None, timestamp=None):
+        '''Clear all data before `timestamp` for a given key. Note that the timestamp
+        is rounded down to the nearest block boundary'''
+        block_size = self.config.block_size
+        if namespace is None:
+            namespace = self.config.namespace
+        if timestamp is not None:
+            offset, remainder = divmod(timestamp, block_size)
+            if remainder:
+                raise ValueError('timestamp must be on a block boundary')
+            self.driver.clear_key_before(key, namespace, offset)
+        else:
+            self.driver.clear_key_before(key, namespace)
+
+    def clear_key_after(self, key, namespace=None, timestamp=None):
+        '''Clear all data after `timestamp` for a given key. Note that the timestamp
+        is rounded down to the nearest block boundary'''
+        block_size = self.config.block_size
+        if namespace is None:
+            namespace = self.config.namespace
+        if timestamp is not None:
+            offset, remainder = divmod(timestamp, block_size)
+            if remainder:
+                raise ValueError('timestamp must be on a block boundary')
+            self.driver.clear_key_after(key, namespace, offset)
+        else:
+            self.driver.clear_key_after(key, namespace)
+
     def parse_query(self, query):
         '''Parse a query string and return an iterator which yields (key, value)'''
         writer = self.writer

--- a/scripts/gauged_migrate.py
+++ b/scripts/gauged_migrate.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from gauged import Gauged
+import argparse
+import logging
+import sys
+
+
+def migrate(options):
+    gauged = Gauged(options.uri)
+    migrations = gauged.driver.prepare_migrations()
+    current_meta = gauged.driver.all_metadata()
+    current_version = current_meta['current_version']
+    goto_version = gauged.VERSION
+    if current_version > goto_version:
+        logging.error("You have a newer schema than the current version")
+        return 1
+    for version, upgrade_script in migrations.iteritems():
+        logging.debug('-' * 20)
+        logging.debug('from/to version : %s/%s', current_version, version)
+        # skip until current version
+        if version <= current_version:
+            logging.debug('skipping because already done')
+            continue
+        elif version > goto_version:
+            logging.debug('skipping because not needed')
+            break
+        # if migration is found but empty, skip to next
+        if not upgrade_script:
+            logging.debug('skipping because migration empty')
+            current_version = version
+            continue
+        # if migration is found, needs to be executed
+        try:
+            if not isinstance(upgrade_script, list):
+                upgrade_script = [upgrade_script]
+            for stmt in upgrade_script:
+                logging.debug('executing %s' % stmt)
+                gauged.driver.cursor.execute(stmt)
+                gauged.driver.db.commit()
+        except:
+            gauged.driver.db.rollback()
+            logging.error('failed to execute %s', upgrade_script)
+            return 1
+        logging.info('successfully migrated to %s', version)
+        gauged.driver.set_metadata({'current_version': version})
+        current_version = version
+
+if __name__ == '__main__':
+    descr = "Migrate a Gauged database to the latest version"
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument(
+        '-d', '--debug',
+        help='Enable full DEBUG logs',
+        action="store_const", dest="loglevel",
+        const=logging.DEBUG,
+        default=logging.WARNING
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        help='Enable basic logging',
+        action="store_const",
+        dest="loglevel", const=logging.INFO
+    )
+    parser.add_argument(
+        '-u', '--uri',
+        help='Uri to the Gauged Database',
+        action="store",
+        required=True
+    )
+    options = parser.parse_args()
+    logging.basicConfig(level=options.loglevel)
+
+    rtn = migrate(options)
+
+    sys.exit(rtn)

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -97,10 +97,10 @@ class TestDriver(TestCase):
     def test_cache(self):
         id_ = sha1('foobar').digest()
         self.assertSequenceEqual(self.driver.get_cache(0, id_, 2, 3, 4), ())
-        self.driver.add_cache(0, id_, 2, [(3, 4), (4, 6)])
+        self.driver.add_cache(0, 9, id_, 2, [(3, 4), (4, 6)])
         self.assertSequenceEqual(self.driver.get_cache(0, id_, 2, 3, 4),
             ((3, 4), (4, 6)))
-        self.driver.add_cache(1, id_, 2, [(3, 4)])
+        self.driver.add_cache(1, 9, id_, 2, [(3, 4)])
         self.assertSequenceEqual(self.driver.get_cache(1, id_, 2, 3, 4), ((3, 4),))
         self.driver.remove_cache(0)
         self.assertSequenceEqual(self.driver.get_cache(0, id_, 2, 3, 4), ())
@@ -139,7 +139,7 @@ class TestDriver(TestCase):
                   ( 1,  2, 3, 'bar', 0x10 )]
         self.driver.replace_blocks(blocks)
         id_ = sha1('foobar').digest()
-        self.driver.add_cache(0, id_, 5, [(13, 4), (15, 4), (18, 4), (23, 6)])
+        self.driver.add_cache(0, 9, id_, 5, [(13, 4), (15, 4), (18, 4), (23, 6)])
         self.driver.set_writer_position('foo', 18)
         self.driver.set_writer_position('bar', 22)
         self.driver.clear_from(2, 20)

--- a/test/test_gauged.py
+++ b/test/test_gauged.py
@@ -549,6 +549,78 @@ class TestGauged(TestCase):
         self.assertEqual(gauged.value('foo', timestamp=40000), 5)
         self.assertEqual(gauged.value('foo', timestamp=40000, namespace=1), 6)
 
+    def test_clear_key_before(self):
+        gauged = Gauged(self.driver, resolution=1000, block_size=10000)
+        with gauged.writer as writer:
+            writer.add({'foo': 1, 'bar': 1}, timestamp=10000)
+            writer.add({'foo': 2, 'bar': 2}, timestamp=20000)
+            writer.add({'foo': 3, 'bar': 3}, timestamp=30000)
+            writer.add({'foo': 4, 'bar': 4}, timestamp=40000, namespace=1)
+        self.assertEqual(gauged.value('foo', timestamp=40000), 3)
+        self.assertEqual(gauged.value('bar', timestamp=40000), 3)
+        self.assertEqual(gauged.value('foo', timestamp=40000, namespace=1), 4)
+        self.assertEqual(gauged.value('bar', timestamp=40000, namespace=1), 4)
+        with gauged.writer as writer:
+            writer.clear_key_before('foo', timestamp=20000)
+        # every value after 20000 stays the same
+        self.assertEqual(gauged.value('foo', timestamp=30000), 3)
+        self.assertEqual(gauged.value('bar', timestamp=30000), 3)
+        # 'foo' value before 20000 is cleared
+        self.assertEqual(gauged.value('foo', timestamp=10000), None)
+        # 'bar' stays there
+        self.assertEqual(gauged.value('bar', timestamp=10000), 1)
+
+        with gauged.writer as writer:
+            writer.add({'foo': 5, 'bar': 5}, timestamp=50000)
+            writer.add({'foo': 5, 'bar': 5}, timestamp=50000, namespace=1)
+            writer.add({'foo': 6, 'bar': 6}, timestamp=60000)
+            writer.add({'foo': 6, 'bar': 6}, timestamp=60000, namespace=1)
+        with gauged.writer as writer:
+            writer.clear_key_before('foo', namespace=1, timestamp=60000)
+        # 'foo' in namespace 0 is untouched before 60000
+        self.assertEqual(gauged.value('foo', timestamp=50000), 5)
+        # 'foo' in namespace 1 is correctly cleared
+        self.assertEqual(gauged.value('foo', timestamp=50000, namespace=1), None)
+        # 'bar' is still there
+        self.assertEqual(gauged.value('bar', timestamp=50000), 5)
+        self.assertEqual(gauged.value('bar', timestamp=50000, namespace=1), 5)
+
+    def test_clear_key_after(self):
+        gauged = Gauged(self.driver, resolution=1000, block_size=10000)
+        with gauged.writer as writer:
+            writer.add({'foo': 1, 'bar': 1}, timestamp=10000)
+            writer.add({'foo': 2, 'bar': 2}, timestamp=20000)
+            writer.add({'foo': 3, 'bar': 3}, timestamp=30000)
+            writer.add({'foo': 4, 'bar': 4}, timestamp=40000, namespace=1)
+        self.assertEqual(gauged.value('foo', timestamp=40000), 3)
+        self.assertEqual(gauged.value('bar', timestamp=40000), 3)
+        self.assertEqual(gauged.value('foo', timestamp=40000, namespace=1), 4)
+        self.assertEqual(gauged.value('bar', timestamp=40000, namespace=1), 4)
+        with gauged.writer as writer:
+            writer.clear_key_after('foo', timestamp=20000)
+        # every value before 20000 stays the same
+        self.assertEqual(gauged.value('foo', timestamp=10000), 1)
+        self.assertEqual(gauged.value('bar', timestamp=10000), 1)
+        # 'foo' value after 20000 is cleared
+        self.assertEqual(gauged.aggregate('foo', Gauged.COUNT, start=30000, end=40000), 0)
+        # 'bar' stays there
+        self.assertEqual(gauged.value('bar', timestamp=10000), 1)
+
+        with gauged.writer as writer:
+            writer.add({'foo': 5, 'bar': 5}, timestamp=50000)
+            writer.add({'foo': 5, 'bar': 5}, timestamp=50000, namespace=1)
+            writer.add({'foo': 6, 'bar': 6}, timestamp=60000)
+            writer.add({'foo': 6, 'bar': 6}, timestamp=60000, namespace=1)
+        with gauged.writer as writer:
+            writer.clear_key_after('foo', namespace=1, timestamp=50000)
+        # 'foo' in namespace 0 is untouched after 50000
+        self.assertEqual(gauged.value('foo', timestamp=60000), 6)
+        # 'foo' in namespace 1 is correctly cleared
+        self.assertEqual(gauged.aggregate('foo', Gauged.COUNT, start=50000, end=60000, namespace=1), 0)
+        # 'bar' is still there
+        self.assertEqual(gauged.value('bar', timestamp=60000), 6)
+        self.assertEqual(gauged.value('bar', timestamp=60000, namespace=1), 6)
+
     def test_gauged_init_store(self):
         gauged = Gauged('sqlite+foo://')
         self.assertEqual(len(gauged.metadata()), 0)

--- a/test/test_gauged.py
+++ b/test/test_gauged.py
@@ -565,6 +565,8 @@ class TestGauged(TestCase):
         # every value after 20000 stays the same
         self.assertEqual(gauged.value('foo', timestamp=30000), 3)
         self.assertEqual(gauged.value('bar', timestamp=30000), 3)
+        # 'foo' value on 20000 is cleared
+        self.assertEqual(gauged.value('foo', timestamp=20000), None)
         # 'foo' value before 20000 is cleared
         self.assertEqual(gauged.value('foo', timestamp=10000), None)
         # 'bar' stays there
@@ -601,8 +603,10 @@ class TestGauged(TestCase):
         # every value before 20000 stays the same
         self.assertEqual(gauged.value('foo', timestamp=10000), 1)
         self.assertEqual(gauged.value('bar', timestamp=10000), 1)
+        # 'foo' value on 20000 is cleared
+        self.assertEqual(gauged.aggregate('foo', Gauged.COUNT, start=19000, end=21000), 0)
         # 'foo' value after 20000 is cleared
-        self.assertEqual(gauged.aggregate('foo', Gauged.COUNT, start=30000, end=40000), 0)
+        self.assertEqual(gauged.aggregate('foo', Gauged.COUNT, start=20000, end=40000), 0)
         # 'bar' stays there
         self.assertEqual(gauged.value('bar', timestamp=10000), 1)
 

--- a/test/test_gauged.py
+++ b/test/test_gauged.py
@@ -559,6 +559,11 @@ class TestGauged(TestCase):
             writer.add({'foo': 2.9, 'bar': 2.9}, timestamp=29999)
             writer.add({'foo': 3, 'bar': 3}, timestamp=30000)
             writer.add({'foo': 4, 'bar': 4}, timestamp=40000, namespace=1)
+        # timestamp should be on a block boundary
+        with gauged.writer as writer:
+            with self.assertRaises(ValueError):
+                writer.clear_key_before('foo', timestamp=15000)
+
         self.assertEqual(gauged.value('foo', timestamp=40000), 3)
         self.assertEqual(gauged.value('bar', timestamp=40000), 3)
         self.assertEqual(gauged.value('foo', timestamp=40000, namespace=1), 4)
@@ -602,6 +607,10 @@ class TestGauged(TestCase):
         self.assertEqual(gauged.value('bar', timestamp=40000), 3)
         self.assertEqual(gauged.value('foo', timestamp=40000, namespace=1), 4)
         self.assertEqual(gauged.value('bar', timestamp=40000, namespace=1), 4)
+        # timestamp should be on a block boundary
+        with gauged.writer as writer:
+            with self.assertRaises(ValueError):
+                writer.clear_key_after('foo', timestamp=15000)
         with gauged.writer as writer:
             writer.clear_key_after('foo', timestamp=20000)
         # every value before 20000 stays the same

--- a/test/test_gauged.py
+++ b/test/test_gauged.py
@@ -352,7 +352,7 @@ class TestGauged(TestCase):
         with self.assertRaises(GaugedVersionMismatchError):
             with gauged.writer:
                 pass
-        gauged.migrate()
+        #gauged.migrate()
 
     def test_accepting_data_as_string(self):
         gauged = Gauged(self.driver, resolution=1000, block_size=10000,


### PR DESCRIPTION
Fixes issue #4

Those are meant mainly for easier maintenance purposes

Notes:
- new methods are meant mainly for easier maintenance purposes
- schema change needs a new version, plus migration scripts
- remember to add in the docs that using the new methods statistics are
  not updated

Unrelated: 
- switched to faster travis-ci infrastructure based on docker
- fails on newer pypy because pythonapi is no longer available
